### PR TITLE
Fix comment in usb_device_close

### DIFF
--- a/src/usb_device.c
+++ b/src/usb_device.c
@@ -72,7 +72,7 @@ usb_device_t *usb_device_open(int vid, int pid) {
 }
 
 void usb_device_close(usb_device_t *device) {
-    // Close device file descriptor
+    // Close device handle
     close(device->fd);
 
     // Free device memory


### PR DESCRIPTION
## Summary
- replace outdated comment in `usb_device_close`

## Testing
- `make clean`
- `make` *(fails: usr/include/linux/usb/ch9.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f473a610483329e6fe43b2e36724e