### PR TITLE
Fix duplicate read_string_descriptor definition

### DIFF
--- a/src/gadgetfs_api.c
+++ b/src/gadgetfs_api.c
@@ -12,23 +12,6 @@
 #include <poll.h>
 
 // Helper function: read a string descriptor from the device
-int read_string_descriptor(libusb_device_handle *dev_handle, uint8_t index, char *buf, size_t buf_len) {
-    if (buf_len < 2) {
-        return LIBUSB_ERROR_OVERFLOW;
-    }
-
-    int r = libusb_get_string_descriptor_ascii(dev_handle, index, (unsigned char *)buf, buf_len);
-    if (r < 0) {
-        return r;
-    }
-
-    if (buf[0] != buf_len || buf[1] != LIBUSB_DT_STRING) {
-        return LIBUSB_ERROR_IO;
-    }
-
-    return r;
-}
-
 static int read_string_descriptor(libusb_device_handle *dev_handle, uint8_t index, char *buf, size_t buf_len) {
     if (buf_len < 2) {
         return LIBUSB_ERROR_OVERFLOW;


### PR DESCRIPTION
## Summary
- consolidate `read_string_descriptor` definition in `gadgetfs_api.c`

## Testing
- `make` *(fails: fatal error: usr/include/linux/usb/ch9.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f47614eb88332bbe17f1948841042