### PR TITLE
Move usbip traffic handler

### DIFF
--- a/src/usb_gadget.c
+++ b/src/usb_gadget.c
@@ -245,33 +245,7 @@ static void *handle_gadgetfs_events(void *arg) {
     return NULL;
 }
 
-
-int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device) {
-    if (!gadgetfs_dir || !device) {
-        return -1;
-    }
-
-    usb_device_info_t device_info;
-
-    // Populate device_info from the libusb_device
-
-    int gadgetfs_fd = gadgetfs_init(gadgetfs_dir, &device_info);
-    if (gadgetfs_fd < 0) {
-        perror("Error initializing GadgetFS");
-        return -1;
-    }
-
-    pthread_t gadgetfs_thread;
-    int thread_create_result = pthread_create(&gadgetfs_thread, NULL, handle_gadgetfs_events, &gadgetfs_fd);
-    if (thread_create_result != 0) {
-        perror("Error creating GadgetFS event handling thread");
-        close(gadgetfs_fd);
-        return -1;
-    }
-
-    // Handle other USB gadget tasks, such as processing USB/IP traffic
-    // and communicating with the GadgetFS events handling thread
-    static void *handle_usbip_traffic(void *arg) {
+void *handle_usbip_traffic(void *arg) {
     libusb_device *device = (libusb_device *)arg;
 
     // Initialize USB/IP traffic handling
@@ -282,7 +256,10 @@ int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device) {
         return NULL;
     }
 
-    libusb_device_handle *handle = libusb_open_device_with_vid_pid(context, libusb_get_device_vendor_id(device), libusb_get_device_product_id(device));
+    libusb_device_handle *handle = libusb_open_device_with_vid_pid(
+        context,
+        libusb_get_device_vendor_id(device),
+        libusb_get_device_product_id(device));
     if (!handle) {
         fprintf(stderr, "Error opening device with USB/IP: %s\n", libusb_error_name(result));
         libusb_exit(context);
@@ -308,7 +285,7 @@ int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device) {
             break;
         }
 
-        // Forward the incoming packet to the appropriate endpoint using the `forward_data` function
+        // Forward the incoming packet to the appropriate endpoint
         usbip_packet_t *in_packet = (usbip_packet_t *)in_buffer;
         usb_transfer_t transfer;
         transfer.endpoint_address = in_packet->base.ep;
@@ -336,6 +313,40 @@ int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device) {
 
     return NULL;
 }
+
+
+int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device) {
+    if (!gadgetfs_dir || !device) {
+        return -1;
+    }
+
+    usb_device_info_t device_info;
+
+    // Populate device_info from the libusb_device
+
+    int gadgetfs_fd = gadgetfs_init(gadgetfs_dir, &device_info);
+    if (gadgetfs_fd < 0) {
+        perror("Error initializing GadgetFS");
+        return -1;
+    }
+
+    pthread_t gadgetfs_thread;
+    int thread_create_result = pthread_create(&gadgetfs_thread, NULL, handle_gadgetfs_events, &gadgetfs_fd);
+    if (thread_create_result != 0) {
+        perror("Error creating GadgetFS event handling thread");
+        close(gadgetfs_fd);
+        return -1;
+    }
+
+    // Create a thread to handle USB/IP traffic
+    pthread_t usbip_thread;
+    thread_create_result = pthread_create(&usbip_thread, NULL, handle_usbip_traffic, device);
+    if (thread_create_result != 0) {
+        perror("Error creating USB/IP handling thread");
+        close(gadgetfs_fd);
+        return -1;
+    }
+
 
 
 

--- a/src/usb_gadget.h
+++ b/src/usb_gadget.h
@@ -7,5 +7,6 @@
 #include "gadgetfs_api.h"
 
 int usb_gadget_start(const char *gadgetfs_dir, libusb_device *device);
+void *handle_usbip_traffic(void *arg);
 
 #endif // USB_GADGET_H


### PR DESCRIPTION
## Summary
- expose `handle_usbip_traffic` in the header
- move `handle_usbip_traffic` out of `usb_gadget_start`
- spawn a thread for USB/IP traffic in `usb_gadget_start`

## Testing
- `make` *(fails: conflicting types for gadgetfs_init, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b184cc48332bf95a5d51dc4e9af