### PR TITLE
Unify usb_device_t definition

### DIFF
--- a/src/usb_device.c
+++ b/src/usb_device.c
@@ -1,157 +1,88 @@
 #include "usb_device.h"
 #include <libusb-1.0/libusb.h>
-#include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <stdio.h>
 
-#define USB_ENDPOINT_IN     LIBUSB_ENDPOINT_IN
-#define USB_ENDPOINT_OUT    LIBUSB_ENDPOINT_OUT
-
-struct usb_device {
-    libusb_device_handle *dev_handle;
-};
-
-usb_device_t *usb_device_open(int vid, int pid) {
-    libusb_device **devs;
-    libusb_device_handle *dev_handle;
-    int r;
-
-    // Initialize libusb
-    r = libusb_init(NULL);
-    if (r < 0) {
-        fprintf(stderr, "Error: Failed to initialize libusb: %s\n", libusb_error_name(r));
-        exit(EXIT_FAILURE);
+usb_device_t* usb_device_open(uint16_t vendor_id, uint16_t product_id) {
+    if (libusb_init(NULL) < 0) {
+        return NULL;
     }
 
-    // Get list of USB devices
-    ssize_t cnt = libusb_get_device_list(NULL, &devs);
-    if (cnt < 0) {
-        fprintf(stderr, "Error: Failed to get list of USB devices: %s\n", libusb_error_name(cnt));
-        exit(EXIT_FAILURE);
+    libusb_device_handle *handle = libusb_open_device_with_vid_pid(NULL, vendor_id, product_id);
+    if (!handle) {
+        libusb_exit(NULL);
+        return NULL;
     }
 
-    // Iterate through devices and find one with matching VID/PID
-    for (ssize_t i = 0; i < cnt; i++) {
-        libusb_device *dev = devs[i];
-        struct libusb_device_descriptor desc;
-
-        r = libusb_get_device_descriptor(dev, &desc);
-        if (r < 0) {
-            fprintf(stderr, "Error: Failed to get device descriptor: %s\n", libusb_error_name(r));
-            continue;
-        }
-
-        if (desc.idVendor == vid && desc.idProduct == pid) {
-            // Open the device
-            r = libusb_open(dev, &dev_handle);
-            if (r < 0) {
-                fprintf(stderr, "Error: Failed to open USB device: %s\n", libusb_error_name(r));
-                continue;
-            }
-
-            // Claim the interface
-            r = libusb_claim_interface(dev_handle, 0);
-            if (r < 0) {
-                fprintf(stderr, "Error: Failed to claim interface: %s\n", libusb_error_name(r));
-                libusb_close(dev_handle);
-                continue;
-            }
-
-            // Free device list and return the device handle
-            libusb_free_device_list(devs, 1);
-            usb_device_t *dev_struct = malloc(sizeof(usb_device_t));
-            dev_struct->dev_handle = dev_handle;
-            return dev_struct;
-        }
+    usb_device_t *dev = calloc(1, sizeof(usb_device_t));
+    if (!dev) {
+        libusb_close(handle);
+        libusb_exit(NULL);
+        return NULL;
     }
-
-    // Free device list and return NULL if no matching device found
-    libusb_free_device_list(devs, 1);
-    return NULL;
+    dev->handle = handle;
+    dev->vendor_id = vendor_id;
+    dev->product_id = product_id;
+    return dev;
 }
 
-void usb_device_close(usb_device_t *device) {
-    // Close device handle
-    close(device->fd);
-
-    // Free device memory
-    free(device);
-}
-
-usb_interface_t* usb_device_get_interface_by_class(usb_device_t *device, uint8_t interface_class) {
-    for (int i = 0; i < device->num_interfaces; i++) {
-        if (device->interfaces[i]->interface_descriptor->bInterfaceClass == interface_class) {
-            return device->interfaces[i];
-        }
-    }
-    return NULL;
-}
-
-usb_interface_t* usb_device_get_interface_by_subclass(usb_device_t *device, uint8_t interface_subclass) {
-    for (int i = 0; i < device->num_interfaces; i++) {
-        if (device->interfaces[i]->interface_descriptor->bInterfaceSubClass == interface_subclass) {
-            return device->interfaces[i];
-        }
-    }
-    return NULL;
-}
-
-usb_interface_t* usb_device_get_interface_by_protocol(usb_device_t *device, uint8_t interface_protocol) {
-    for (int i = 0; i < device->num_interfaces; i++) {
-        if (device->interfaces[i]->interface_descriptor->bInterfaceProtocol == interface_protocol) {
-            return device->interfaces[i];
-        }
-    }
-    return NULL;
-}
-
-void usb_device_reset(usb_device_t *device) {
-    int res = ioctl(device->fd, USBDEVFS_RESET, 0);
-    if (res < 0) {
-        perror("Error: Failed to reset USB device.");
-    }
-}
-
-int usb_device_control_transfer(usb_device_handle_t *dev_handle, uint8_t bmRequestType, uint8_t bRequest,
-                                uint16_t wValue, uint16_t wIndex, unsigned char *data, uint16_t wLength,
-                                unsigned int timeout_ms) {
-    int ret = libusb_control_transfer(dev_handle->handle, bmRequestType, bRequest, wValue, wIndex, data, wLength,
-                                      timeout_ms);
-    if (ret < 0) {
-        fprintf(stderr, "Error: Failed to perform USB control transfer: %s.\n", libusb_error_name(ret));
-        return -1;
-    }
-
-    return ret;
-}
-
-void usb_device_close(usb_device_handle_t *dev_handle) {
-    if (dev_handle == NULL) {
-        fprintf(stderr, "Error: Device handle is NULL.\n");
+void usb_device_close(usb_device_t *dev) {
+    if (!dev) {
         return;
     }
-
-    libusb_close(dev_handle->handle);
-    free(dev_handle);
+    if (dev->handle) {
+        libusb_close(dev->handle);
+    }
+    libusb_exit(NULL);
+    free(dev);
 }
 
-int usb_device_claim_interface(usb_device_handle_t *dev_handle, int interface_number) {
-    int ret = libusb_claim_interface(dev_handle->handle, interface_number);
-    if (ret < 0) {
-        fprintf(stderr, "Error: Failed to claim interface %d: %s.\n", interface_number, libusb_error_name(ret));
-        return -1;
+bool usb_device_control_transfer(usb_device_t *dev, uint8_t bmRequestType, uint8_t bRequest,
+                                 uint16_t wValue, uint16_t wIndex, unsigned char *data,
+                                 uint16_t wLength, unsigned int timeout) {
+    if (!dev || !dev->handle) {
+        return false;
     }
-
-    return ret;
+    int r = libusb_control_transfer(dev->handle, bmRequestType, bRequest,
+                                    wValue, wIndex, data, wLength, timeout);
+    return r >= 0;
 }
 
-int usb_device_release_interface(usb_device_handle_t *dev_handle, int interface_number) {
-    int ret = libusb_release_interface(dev_handle->handle, interface_number);
-    if (ret < 0) {
-        fprintf(stderr, "Error: Failed to release interface %d: %s.\n", interface_number, libusb_error_name(ret));
-        return -1;
+bool usb_device_bulk_transfer(usb_device_t *dev, unsigned char endpoint, unsigned char *data,
+                              int length, int *transferred, unsigned int timeout) {
+    if (!dev || !dev->handle) {
+        return false;
     }
+    int r = libusb_bulk_transfer(dev->handle, endpoint, data, length, transferred, timeout);
+    return r == 0;
+}
 
-    return ret;
+bool usb_device_interrupt_transfer(usb_device_t *dev, unsigned char endpoint, unsigned char *data,
+                                   int length, int *transferred, unsigned int timeout) {
+    if (!dev || !dev->handle) {
+        return false;
+    }
+    int r = libusb_interrupt_transfer(dev->handle, endpoint, data, length, transferred, timeout);
+    return r == 0;
+}
+
+bool usb_device_claim_interface(usb_device_t *dev, int interface_number) {
+    if (!dev || !dev->handle) {
+        return false;
+    }
+    return libusb_claim_interface(dev->handle, interface_number) == 0;
+}
+
+bool usb_device_release_interface(usb_device_t *dev, int interface_number) {
+    if (!dev || !dev->handle) {
+        return false;
+    }
+    return libusb_release_interface(dev->handle, interface_number) == 0;
+}
+
+bool usb_device_reset(usb_device_t *dev) {
+    if (!dev || !dev->handle) {
+        return false;
+    }
+    return libusb_reset_device(dev->handle) == 0;
 }

--- a/src/usb_interface.c
+++ b/src/usb_interface.c
@@ -1,103 +1,20 @@
 #include "usb_interface.h"
-#include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
-#include <linux/usbdevice_fs.h>
-
-#define USBFS_CONTROL_REQUEST_TYPE 0x21
-#define USBFS_CONTROL_REQUEST      0x09
-
-#define USBFS_IOCTL_RETRY 4
-
-struct usb_interface {
-    uint8_t interface_number;
-    uint8_t alternate_setting;
-    int interface_fd;
-};
-
-usb_interface_t* usb_interface_create(uint8_t interface_number, uint8_t alternate_setting) {
-    usb_interface_t *interface = (usb_interface_t *)malloc(sizeof(usb_interface_t));
-    if (interface == NULL) {
-        fprintf(stderr, "Error: Failed to allocate memory for USB interface.\n");
-        exit(EXIT_FAILURE);
-    }
-
-    interface->interface_number = interface_number;
-    interface->alternate_setting = alternate_setting;
-    interface->interface_fd = -1;
-
-    return interface;
-}
 
 void usb_interface_destroy(usb_interface_t *interface) {
-    if (interface != NULL) {
-        if (interface->interface_fd >= 0) {
-            close(interface->interface_fd);
-        }
-        free(interface);
-    }
+    free(interface);
 }
 
 bool usb_interface_claim(usb_interface_t *interface) {
-    if (interface == NULL) {
+    if (!interface || !interface->handle) {
         return false;
     }
-
-    char filename[64];
-    sprintf(filename, "/dev/bus/usb/%03d/%03d", 0, interface->interface_number);
-
-    int interface_fd = open(filename, O_RDWR);
-    if (interface_fd < 0) {
-        fprintf(stderr, "Error: Failed to open USB interface %d.\n", interface->interface_number);
-        return false;
-    }
-
-    struct usbdevfs_ioctl command;
-    command.ifno = interface->interface_number;
-    command.ioctl_code = USBDEVFS_IOCTL_CLAIM_INTERFACE;
-    command.data = &interface->alternate_setting;
-    command.length = sizeof(interface->alternate_setting);
-    command.flags = USBDEVFS_IOCTL_RETRIES | USBDEVFS_REAPURB;
-
-    for (int i = 0; i < USBFS_IOCTL_RETRY; ++i) {
-        if (ioctl(interface_fd, USBDEVFS_IOCTL, &command) < 0) {
-            perror("ioctl");
-            close(interface_fd);
-            return false;
-        }
-        if (command.status == 0) {
-            interface->interface_fd = interface_fd;
-            return true;
-        }
-        usleep(1000);
-    }
-
-    close(interface_fd);
-    return false;
+    return libusb_claim_interface(interface->handle, interface->interface_number) == 0;
 }
 
 bool usb_interface_release(usb_interface_t *interface) {
-    if (interface->claimed) {
-        if (usb_device_release_interface(interface->device->handle, interface->number) < 0) {
-            perror("Error releasing interface");
-            return false;
-        }
-        interface->claimed = false;
-    }
-    return true;
-}
-
-bool usb_interface_reset(usb_interface_t *interface) {
-    if (!interface->claimed) {
-        fprintf(stderr, "Error: Interface must be claimed before it can be reset.\n");
+    if (!interface || !interface->handle) {
         return false;
     }
-    if (usb_device_reset(interface->device) == -1) {
-        perror("Error resetting device");
-        return false;
-    }
-    return true;
+    return libusb_release_interface(interface->handle, interface->interface_number) == 0;
 }

--- a/src/usb_interface.h
+++ b/src/usb_interface.h
@@ -11,20 +11,6 @@ typedef struct {
     uint8_t interface_number;
 } usb_interface_t;
 
-typedef struct {
-    libusb_device *device;
-    libusb_device_handle *handle;
-    uint8_t bus_number;
-    uint8_t device_address;
-    uint16_t vendor_id;
-    uint16_t product_id;
-    uint8_t configuration;
-    usb_interface_t *interfaces;
-    int num_interfaces;
-} usb_device_t;
-
-typedef struct usb_interface usb_interface_t;
-
 usb_device_t *usb_device_open(uint16_t vendor_id, uint16_t product_id);
 void usb_device_close(usb_device_t *device);
 bool usb_device_control_transfer(usb_device_t *device, uint8_t request_type, uint8_t request, uint16_t value, uint16_t index, uint8_t *data, uint16_t length, uint32_t timeout);
@@ -32,7 +18,8 @@ bool usb_device_bulk_transfer(usb_device_t *device, uint8_t endpoint_address, ui
 bool usb_device_interrupt_transfer(usb_device_t *device, uint8_t endpoint_address, uint8_t *data,uint32_t length, uint32_t timeout);
 bool usb_device_claim_interface(usb_device_t *device, uint8_t interface_number);
 bool usb_device_release_interface(usb_device_t *device, uint8_t interface_number);
-bool usb_device_reset(usb_device_t *device);void usb_interface_destroy(usb_interface_t *interface);
+bool usb_device_reset(usb_device_t *device);
+void usb_interface_destroy(usb_interface_t *interface);
 bool usb_interface_claim(usb_interface_t *interface);
 bool usb_interface_release(usb_interface_t *interface);
 


### PR DESCRIPTION
## Summary
- use single `usb_device_t` definition across headers
- clean up `usb_interface.h` and `usb_interface.c`
- rewrite `usb_device.c` with libusb implementation

## Testing
- `make` *(fails: libusb headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b1a2f6c833293605c4e1d42a5aa