### PR TITLE
Append libusb flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -pthread
-LDFLAGS = -ludev
+LDFLAGS = -ludev -lusb-1.0
 
 SRC_DIR = src
 BUILD_DIR = build


### PR DESCRIPTION
## Summary
- link libusb in `Makefile`

## Testing
- `apt-get install -y libusb-1.0-0-dev`
- `make` *(fails: conflicting types in `gadgetfs_api.c`)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b30d8908332bce06e128d567fa0