### PR TITLE
Add missing common header for transfer structs

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,21 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Basic data structure for interrupt transfers. */
+typedef struct {
+    int endpoint_fd;
+    void *data;
+    size_t length;
+} interrupt_transfer_t;
+
+/* Basic data structure for bulk transfers. */
+typedef struct {
+    int endpoint_fd;
+    void *data;
+    size_t length;
+} bulk_transfer_t;
+
+#endif /* COMMON_H */

--- a/src/interrupt_transfer_queue.h
+++ b/src/interrupt_transfer_queue.h
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include "transfer.h"
+#include "common.h"
 
 typedef struct {
     interrupt_transfer_t *buffer;

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include "isochronous_transfer_queue.h"
 #include "interrupt_transfer_queue.h"
 #include "bulk_transfer_queue.h"
+#include "common.h"
 
 typedef enum {
     CONNECTION_NONE,


### PR DESCRIPTION
## Summary
- provide `src/common.h` defining bulk and interrupt transfer structs
- include the new header in modules using these types

## Testing
- `make` *(fails: libusb not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b33df40833297724619e24d77dd