### PR TITLE
Implement control transfer queue

### DIFF
--- a/src/control_transfer_queue.c
+++ b/src/control_transfer_queue.c
@@ -1,0 +1,49 @@
+#include "control_transfer_queue.h"
+
+void control_transfer_queue_init(control_transfer_queue_t *queue,
+                                 control_transfer_t *buffer,
+                                 int size) {
+    queue->transfers = buffer;
+    queue->size = size;
+    queue->head = 0;
+    queue->tail = 0;
+    queue->full = false;
+}
+
+bool control_transfer_queue_enqueue(control_transfer_queue_t *queue,
+                                    const control_transfer_t *transfer) {
+    if (queue->full) {
+        return false;
+    }
+
+    queue->transfers[queue->tail] = *transfer;
+    queue->tail = (queue->tail + 1) % queue->size;
+
+    if (queue->tail == queue->head) {
+        queue->full = true;
+    }
+
+    return true;
+}
+
+bool control_transfer_queue_dequeue(control_transfer_queue_t *queue,
+                                    control_transfer_t *transfer) {
+    if (!queue->full && queue->head == queue->tail) {
+        return false;
+    }
+
+    *transfer = queue->transfers[queue->head];
+    queue->head = (queue->head + 1) % queue->size;
+    queue->full = false;
+
+    return true;
+}
+
+void control_transfer_queue_destroy(control_transfer_queue_t *queue) {
+    /* No dynamic allocations to free for now */
+    queue->transfers = NULL;
+    queue->size = 0;
+    queue->head = 0;
+    queue->tail = 0;
+    queue->full = false;
+}

--- a/src/control_transfer_queue.h
+++ b/src/control_transfer_queue.h
@@ -1,0 +1,24 @@
+#ifndef CONTROL_TRANSFER_QUEUE_H
+#define CONTROL_TRANSFER_QUEUE_H
+
+#include <stdbool.h>
+#include "transfer_request.h"
+
+typedef struct {
+    control_transfer_t *transfers;
+    int size;
+    int head;
+    int tail;
+    bool full;
+} control_transfer_queue_t;
+
+void control_transfer_queue_init(control_transfer_queue_t *queue,
+                                 control_transfer_t *buffer,
+                                 int size);
+bool control_transfer_queue_enqueue(control_transfer_queue_t *queue,
+                                    const control_transfer_t *transfer);
+bool control_transfer_queue_dequeue(control_transfer_queue_t *queue,
+                                    control_transfer_t *transfer);
+void control_transfer_queue_destroy(control_transfer_queue_t *queue);
+
+#endif /* CONTROL_TRANSFER_QUEUE_H */


### PR DESCRIPTION
## Summary
- add queue implementation for control transfers
- include new queue source in build automatically via wildcard

## Testing
- `make` *(fails: gadgetfs_api build errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b37e82c833283aa08fcc6d2fdfc